### PR TITLE
check if directory exists before trying to create it

### DIFF
--- a/cloudsend.sh
+++ b/cloudsend.sh
@@ -637,10 +637,15 @@ createDirRun() {
         local _path="$FULLPATHENC"
         [[ "$2" == "base" ]] && _path="/$(encodeLink "$ROOTPATH")"  # if we are creating the base target folders
 
+        if "$CURLBIN"$INSECURE$REFERER -A "$USERAGENT" --silent -X PROPFIND -u "$FOLDERTOKEN":"$PASSWORD" -H "$HEADER" "$CLOUDURL/$PUBSUFFIX$_path/$1" | "$CATBIN" ; then
+                echo "Directory $_path/$1 already exists."
+                return 0
+        fi
+
         if hasUserAgent; then
                 "$CURLBIN"$INSECURE$REFERER -A "$USERAGENT" --silent -X MKCOL -u "$FOLDERTOKEN":"$PASSWORD" -H "$HEADER" "$CLOUDURL/$PUBSUFFIX$_path/$1" | "$CATBIN" ; test ${PIPESTATUS[0]} -eq 0
         else
-                                "$CURLBIN"$INSECURE$REFERER --silent -X MKCOL -u "$FOLDERTOKEN":"$PASSWORD" -H "$HEADER" "$CLOUDURL/$PUBSUFFIX$_path/$1" | "$CATBIN" ; test ${PIPESTATUS[0]} -eq 0
+                "$CURLBIN"$INSECURE$REFERER --silent -X MKCOL -u "$FOLDERTOKEN":"$PASSWORD" -H "$HEADER" "$CLOUDURL/$PUBSUFFIX$_path/$1" | "$CATBIN" ; test ${PIPESTATUS[0]} -eq 0
         fi
         ecode=$?
         curlAddExitCode $ecode


### PR DESCRIPTION
nextcloud returns Internal Server Error when trying to upload to directory that already exists
this checks if it exists and if it does it won't try to create it again and instead uses the existing one

```
‗‗‗‗‗‗‗‗‗‗
 CURL LOG
‾‾‾‾‾‾‾‾‾‾
CREATE DIR ERROR FOR "1.1.1"
<?xml version="1.0" encoding="utf-8"?>
<d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
        <s:exception>Internal Server Error</s:exception>
        <s:message>
                The server was unable to complete your request.         If this happens again, please send the technical details below to the server administrator.             More details can be found in the server log.                    </s:message>

        <s:technical-details>
                <s:remote-address>x.x.x.x</s:remote-address>
                <s:request-id>ia96ZqKXecFWX7c3jjWP</s:request-id>

                </s:technical-details>
</d:error>
```